### PR TITLE
Setpoint tuneup

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -82,14 +82,14 @@ public final class Constants {
     public static final double L2_SETUP_ANGLE = 115;
     public static final double L3_SETUP_ANGLE = 108;
     public static final double L4_SETUP_ANGLE = 97;
-    public static final double L2_SCORE_ANGLE = 133;
+    public static final double L2_SCORE_ANGLE = 140;
     public static final double L3_SCORE_ANGLE = 115;
     public static final double L4_SCORE_ANGLE = 97;
 
     // Extension in rotations
     public static final double STAB_EXTENSION = 0.02;
     public static final double IDLE_EXTENSION = 0.02;
-    public static final double L2_EXTENSION = 0.85;
+    public static final double L2_EXTENSION = 0.8;
     public static final double L3_EXTENSION = 1.95;
     public static final double L4_EXTENSION = 4.3;
   }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -67,7 +67,7 @@ public final class Constants {
     public static final int EXTENDER_ENCODER_ID = 16;
     public static final int CANDI_ID = 17; // S1 is rotation, S2 is extension
     public static final double ROTATOR_GEAR_RATIO = 25;
-    public static final double ROTATOR_FORWARD_LIMIT = 0.34;
+    public static final double ROTATOR_FORWARD_LIMIT = 0.388;
     public static final double ROTATOR_REVERSE_LIMIT = 0.0;
     //    public static final double EXTENDER_CANCODER_RATIO = 101.6 / 40;
     //    public static final double EXTENDER_GEAR_RATIO = 25;
@@ -82,7 +82,7 @@ public final class Constants {
     public static final double L2_SETUP_ANGLE = 115;
     public static final double L3_SETUP_ANGLE = 108;
     public static final double L4_SETUP_ANGLE = 97;
-    public static final double L2_SCORE_ANGLE = 140;
+    public static final double L2_SCORE_ANGLE = 135;
     public static final double L3_SCORE_ANGLE = 115;
     public static final double L4_SCORE_ANGLE = 97;
 
@@ -90,7 +90,8 @@ public final class Constants {
     public static final double STAB_EXTENSION = 0.02;
     public static final double IDLE_EXTENSION = 0.02;
     public static final double L2_EXTENSION = 0.8;
-    public static final double L3_EXTENSION = 1.95;
+    public static final double L3_EXTENSION = 2.1;
+
     public static final double L4_EXTENSION = 4.3;
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -268,6 +268,9 @@ public class RobotContainer {
     controller.b().onTrue(reef);
     controller.x().onTrue(Commands.runOnce(() -> currentOnTheFlyCommand.schedule()));
 
+    controller.rightBumper().onTrue(extendBoathook);
+    controller.rightTrigger().onTrue(retractBoathook);
+
     controller.leftBumper().whileTrue(rejectCoral);
     controller.leftTrigger().whileTrue(pullInCoral);
     controller.y().onTrue(moveIntake);
@@ -317,6 +320,9 @@ public class RobotContainer {
       if (angle > 180) angle -= 360;
     }
 
+    System.out.println("Target X: " + x);
+    System.out.println("Target Y: " + y);
+
     // initializes new pathFindToPose command which both create a path and has the robot follow said
     // path
     return AutoBuilder.pathfindToPose(
@@ -327,10 +333,13 @@ public class RobotContainer {
   // overloading allows for creating building blocks that only align or only score
   // IE returning to human player doesent need to run a score after it finished auto aligning
   private Command getScoringBuildingBlock(SetLevelCommand scoreLevel) {
-	Command scoreWaitCommand = new WaitCommand(2);
+    Command scoreWaitCommand = new WaitCommand(2);
     if (RobotBase.isReal()) {
       return new SequentialCommandGroup(
-          scoreLevel, extendBoathook, scoreWaitCommand, retractBoathook);
+          scoreLevel.getNew(),
+          new BoathookExtendMotionPathCommand(boathook),
+          scoreWaitCommand,
+          new BoathookRetractMotionPathCommand(boathook));
     }
 
     return scoreWaitCommand;

--- a/src/main/java/frc/robot/commands/autoCommands/OnTheFlyTargetPose.java
+++ b/src/main/java/frc/robot/commands/autoCommands/OnTheFlyTargetPose.java
@@ -3,7 +3,7 @@ package frc.robot.commands.autoCommands;
 import frc.robot.game.ReefAprilTag;
 
 public enum OnTheFlyTargetPose {
-  // all defined as x/y locations on the field 
+  // all defined as x/y locations on the field
   // the relative (0, 0) is the right corner of the blue driver station
   TWO_LEFT(5.1, 2.82, 120, ReefAprilTag.TWO, Direction.LEFT),
   FOUR_LEFT(3.76, 2.98, 60, ReefAprilTag.FOUR, Direction.LEFT),

--- a/src/main/java/frc/robot/commands/boathookCommands/BoathookExtendMotionPathCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/BoathookExtendMotionPathCommand.java
@@ -5,9 +5,9 @@
 package frc.robot.commands.boathookCommands;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import frc.robot.commands.boathookCommands.setpointCommands.Angle1BoathookCommand;
-import frc.robot.commands.boathookCommands.setpointCommands.Angle2BoathookCommand;
-import frc.robot.commands.boathookCommands.setpointCommands.ExtendBoathookCommand1;
+import frc.robot.commands.boathookCommands.setpointCommands.AngleIdleBoathookCommand;
+import frc.robot.commands.boathookCommands.setpointCommands.ExtendBoathookCommand;
+import frc.robot.commands.boathookCommands.setpointCommands.ExtendBoathookCommandIdle;
 import frc.robot.subsystems.boathook.Boathook;
 
 // NOTE:  Consider using this command inline, rather than writing a subclass.  For more
@@ -19,8 +19,8 @@ public class BoathookExtendMotionPathCommand extends SequentialCommandGroup {
     // Add your commands in the addCommands() call, e.g.
     // addCommands(new FooCommand(), new BarCommand());
     addCommands(
-        new Angle1BoathookCommand(boathook),
-        new ExtendBoathookCommand1(boathook),
-        new Angle2BoathookCommand(boathook));
+        new AngleIdleBoathookCommand(boathook),
+        new ExtendBoathookCommandIdle(boathook),
+        new ExtendBoathookCommand(boathook));
   }
 }

--- a/src/main/java/frc/robot/commands/boathookCommands/BoathookRetractMotionPathCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/BoathookRetractMotionPathCommand.java
@@ -5,11 +5,9 @@
 package frc.robot.commands.boathookCommands;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import frc.robot.commands.boathookCommands.setpointCommands.Angle3BoathookCommand;
 import frc.robot.commands.boathookCommands.setpointCommands.AngleIdleBoathookCommand;
-import frc.robot.commands.boathookCommands.setpointCommands.ExtendBoathookCommand2;
-import frc.robot.commands.boathookCommands.setpointCommands.ExtendBoathookCommand3;
 import frc.robot.commands.boathookCommands.setpointCommands.ExtendBoathookCommandIdle;
+import frc.robot.commands.boathookCommands.setpointCommands.RetractBoathookCommand;
 import frc.robot.subsystems.boathook.Boathook;
 
 // NOTE:  Consider using this command inline, rather than writing a subclass.  For more
@@ -21,10 +19,8 @@ public class BoathookRetractMotionPathCommand extends SequentialCommandGroup {
     // Add your commands in the addCommands() call, e.g.
     // addCommands(new FooCommand(), new BarCommand());
     addCommands(
-        new ExtendBoathookCommand2(boathook),
-        new Angle3BoathookCommand(boathook),
-        new ExtendBoathookCommand3(boathook),
+        new RetractBoathookCommand(boathook),
+        new ExtendBoathookCommandIdle(boathook),
         new AngleIdleBoathookCommand(boathook));
-    new ExtendBoathookCommandIdle(boathook);
   }
 }

--- a/src/main/java/frc/robot/commands/boathookCommands/SetLevelCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/SetLevelCommand.java
@@ -18,6 +18,10 @@ public class SetLevelCommand extends Command {
     this.level = level;
   }
 
+  public SetLevelCommand getNew() {
+    return new SetLevelCommand(this.level);
+  }
+
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {

--- a/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle1BoathookCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle1BoathookCommand.java
@@ -38,6 +38,6 @@ public class Angle1BoathookCommand extends Command {
   public boolean isFinished() {
     return Math.abs(
             boathook.getAngle() - (boathook.getLevel().angle1 + boathook.microRotationOffset))
-        < 5;
+        < 8;
   }
 }

--- a/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle1BoathookCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle1BoathookCommand.java
@@ -27,6 +27,7 @@ public class Angle1BoathookCommand extends Command {
     boathook.setAngle(boathook.getLevel().angle1 + boathook.microRotationOffset);
     System.out.println("CURRENT ANGLE: " + boathook.getAngle());
     System.out.println("SET ANGLE: " + (boathook.getLevel().angle1 + boathook.microRotationOffset));
+    System.out.println("SET POINT ANGLE: " + boathook.getAngleSetpoint());
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle2BoathookCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle2BoathookCommand.java
@@ -38,6 +38,6 @@ public class Angle2BoathookCommand extends Command {
   public boolean isFinished() {
     return Math.abs(
             boathook.getAngle() - (boathook.getLevel().angle2 + boathook.microRotationOffset))
-        < 5;
+        < 8;
   }
 }

--- a/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle2BoathookCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle2BoathookCommand.java
@@ -27,6 +27,7 @@ public class Angle2BoathookCommand extends Command {
     boathook.setAngle(boathook.getLevel().angle2 + boathook.microRotationOffset);
     System.out.println("CURRENT ANGLE: " + boathook.getAngle());
     System.out.println("SET ANGLE: " + (boathook.getLevel().angle2 + boathook.microRotationOffset));
+    System.out.println("SET POINT ANGLE: " + boathook.getAngleSetpoint());
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle3BoathookCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/Angle3BoathookCommand.java
@@ -38,6 +38,6 @@ public class Angle3BoathookCommand extends Command {
   public boolean isFinished() {
     return Math.abs(
             boathook.getAngle() - (boathook.getLevel().angle3 + boathook.microRotationOffset))
-        < 5;
+        < 8;
   }
 }

--- a/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/ExtendBoathookCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/ExtendBoathookCommand.java
@@ -8,10 +8,12 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.boathook.Boathook;
 
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
-public class Angle3BoathookCommand extends Command {
+public class ExtendBoathookCommand extends Command {
   Boathook boathook;
+  double boathookAngle;
+  double boathookLength;
   /** Creates a new AngleBoathookCommand. */
-  public Angle3BoathookCommand(Boathook boathook) {
+  public ExtendBoathookCommand(Boathook boathook) {
     // Use addRequirements() here to declare subsystem dependencies.
     this.boathook = boathook;
     addRequirements(boathook);
@@ -19,15 +21,20 @@ public class Angle3BoathookCommand extends Command {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {}
+  public void initialize() {
+    this.boathookAngle = boathook.getLevel().angle2;
+    this.boathookLength = boathook.getLevel().length1;
+    System.out.println("New Boathook Command Started");
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    boathook.setAngle(boathook.getLevel().angle3 + boathook.microRotationOffset);
-    System.out.println("CURRENT ANGLE: " + boathook.getAngle());
-    System.out.println("SET ANGLE: " + (boathook.getLevel().angle3 + boathook.microRotationOffset));
-    System.out.println("SET POINT ANGLE: " + boathook.getAngleSetpoint());
+    boathook.setAngle(boathookAngle);
+    boathook.setLength(boathookLength);
+    // System.out.println("CURRENT ANGLE: " + boathook.getAngle());
+    // System.out.println("SET ANGLE: " + (boathookAngle));
+    // System.out.println("SET POINT ANGLE: " + boathook.getAngleSetpoint());
   }
 
   // Called once the command ends or is interrupted.
@@ -37,8 +44,7 @@ public class Angle3BoathookCommand extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return Math.abs(
-            boathook.getAngle() - (boathook.getLevel().angle3 + boathook.microRotationOffset))
-        < 8;
+    return Math.abs(boathook.getAngle() - (boathookAngle)) < 8
+        && Math.abs(boathook.getLength() - boathookLength) < 0.1;
   }
 }

--- a/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/RetractBoathookCommand.java
+++ b/src/main/java/frc/robot/commands/boathookCommands/setpointCommands/RetractBoathookCommand.java
@@ -8,10 +8,12 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.boathook.Boathook;
 
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
-public class Angle3BoathookCommand extends Command {
+public class RetractBoathookCommand extends Command {
   Boathook boathook;
+  double boathookAngle;
+  double boathookLength;
   /** Creates a new AngleBoathookCommand. */
-  public Angle3BoathookCommand(Boathook boathook) {
+  public RetractBoathookCommand(Boathook boathook) {
     // Use addRequirements() here to declare subsystem dependencies.
     this.boathook = boathook;
     addRequirements(boathook);
@@ -19,15 +21,20 @@ public class Angle3BoathookCommand extends Command {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {}
+  public void initialize() {
+    this.boathookAngle = boathook.getLevel().angle3;
+    this.boathookLength = boathook.getLevel().length2;
+    System.out.println("New Boathook Command Started");
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    boathook.setAngle(boathook.getLevel().angle3 + boathook.microRotationOffset);
-    System.out.println("CURRENT ANGLE: " + boathook.getAngle());
-    System.out.println("SET ANGLE: " + (boathook.getLevel().angle3 + boathook.microRotationOffset));
-    System.out.println("SET POINT ANGLE: " + boathook.getAngleSetpoint());
+    boathook.setAngle(boathookAngle);
+    boathook.setLength(boathookLength);
+    // System.out.println("CURRENT ANGLE: " + boathook.getAngle());
+    // System.out.println("SET ANGLE: " + (boathookAngle));
+    // System.out.println("SET POINT ANGLE: " + boathook.getAngleSetpoint());
   }
 
   // Called once the command ends or is interrupted.
@@ -37,8 +44,7 @@ public class Angle3BoathookCommand extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return Math.abs(
-            boathook.getAngle() - (boathook.getLevel().angle3 + boathook.microRotationOffset))
-        < 8;
+    return Math.abs(boathook.getAngle() - (boathookAngle)) < 8
+        && Math.abs(boathook.getLength() - boathookLength) < 0.1;
   }
 }

--- a/src/main/java/frc/robot/subsystems/boathook/Boathook.java
+++ b/src/main/java/frc/robot/subsystems/boathook/Boathook.java
@@ -209,6 +209,11 @@ public class Boathook extends SubsystemBase {
     return angle.getValueAsDouble() * 360.0;
   }
 
+  public double getAngleSetpoint() {
+    StatusSignal<Double> angle = rotationMotor.getClosedLoopReference();
+    return angle.getValueAsDouble() * 360;
+  }
+
   public void setLength(double length) {
     extenderMotor.setControl(new PositionVoltage(length));
   }


### PR DESCRIPTION
Simple set point tuneup for boathooks. Simplified extend and retract motion path, extended software limit for angle of boathooks so we can score L2 properly. 